### PR TITLE
Separate keypair name from filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Configuration
 
 When using the `aws` provider to `vagrant up` it is necessary to define several environment variables in order to authenticate to AWS and supply a keypair with which Vagrant can log in to the new AWS EC2 instance being deployed.  These environment variables are as follows:
 
-- `KEYPAIR_NAME`: the name of the AWS keypair that will be used to log in to the instance. This should also be the same as the keypair private key file.  This keypair should already exist within your AWS account and its private key file should reside on the local system.
-- `KEYPAIR_PATH`: the path of the directory on the local system in which the aforementioned keypair private key file resides (e.g., `~/.ssh`).
+- `KEYPAIR_NAME`: the name of the AWS keypair that will be used to log in to the instance. This keypair should already exist within your AWS account and its private key file should reside on the local system.
+- `KEYPAIR_FILE`: the pathname of the private key on the local system corresponding to the aforementioned keypair.
 - `AWS_ACCESS_KEY`: the AWS IAM access key to the account under which the EC2 instance will be created.
 - `AWS_SECRET_KEY`: the AWS IAM secret key to the account under which the EC2 instance will be created.
 
@@ -36,8 +36,8 @@ WARNING: Many of the other AWS EC2 instance settings (e.g., instance type, secur
 
 When deploying to the OpenStack Chameleon Cloud, several environment variables must be defined in order to authenticate to OpenStack and define a keypair to be used to log in to the new Chameleon Cloud instance being deployed.  The following environment variables must be defined:
 
-- `KEYPAIR_NAME`: the name of the OpenStack keypair that will be used to log in to the instance. This should also be the same as the keypair private key file.  This keypair should already exist within your OpenStack account and its private key file should reside on the local system.
-- `KEYPAIR_PATH`: the path of the directory on the local system in which the aforementioned keypair private key file resides (e.g., `~/.ssh`).
+- `KEYPAIR_NAME`: the name of the OpenStack keypair that will be used to log in to the instance. This keypair should already exist within your OpenStack account and its private key file should reside on the local system.
+- `KEYPAIR_FILE`: the pathname of the private key on the local system corresponding to the aforementioned keypair.
 - `OS_FLOATING_IP`: The floating IP address (as a "dotted quad", i.e., x.x.x.x) to be assigned to this instance. This floating IP must already be available to the OpenStack project under which the instance is being deployed.
 - `OS_USERNAME`: your OpenStack user name
 - `OS_PASSWORD`: your OpenStack login password

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,8 +25,8 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provider :aws do |aws, override|
-    keypair = ENV['KEYPAIR_NAME']
-    keypath = ENV['KEYPAIR_PATH']
+    keypair = "#{ENV['KEYPAIR_NAME']}"
+    keypair_filename = "#{ENV['KEYPAIR_FILE']}"
     override.vm.synced_folder '.', '/vagrant', :disabled => true
     override.vm.box = "aws_dummy"
     override.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
@@ -40,7 +40,7 @@ Vagrant.configure(2) do |config|
     aws.security_groups = ["default_vpc_web_vt_ssh"]
     #aws.associate_public_ip = true
     override.ssh.username = "ubuntu"
-    override.ssh.private_key_path = "#{keypath}/#{keypair}"
+    override.ssh.private_key_path = "#{keypair_filename}"
     aws.tags = {
       'Name' => "GeoBlacklight #{keypair}"
     }
@@ -49,12 +49,12 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider :openstack do |os, override|
     keypair = "#{ENV['KEYPAIR_NAME']}"
-    keypath = "#{ENV['KEYPAIR_PATH']}"
+    keypair_filename = "#{ENV['KEYPAIR_FILE']}"
     override.vm.synced_folder '.', '/vagrant', :disabled => true
     override.vm.box = "openstack_dummy"
     override.vm.box_url = "https://github.com/cloudbau/vagrant-openstack-plugin/raw/master/dummy.box"
     override.vm.box_check_update = false
-    override.ssh.private_key_path = "#{keypath}/#{keypair}"
+    override.ssh.private_key_path = "#{keypair_filename}"
     os.username     = "#{ENV['OS_USERNAME']}"  # e.g. "#{ENV['OS_USERNAME']}"
     os.api_key      = "#{ENV['OS_PASSWORD']}"  # e.g. "#{ENV['OS_PASSWORD']}"
     os.flavor       = /m1.medium/               # Regex or String


### PR DESCRIPTION
Currently, the name of the AWS or OpenStack keypair must match the
filename of the corresponding private key. AWS, by default, uses a
".pem" extension on private keys generated for download. With the
existing restriction, such private keys must be renamed to work with
the deployment script.

This change decouples the name of the private key from the name of the
keypair used in AWS or OpenStack.  Now, instead of KEYPAIR_PATH (which
pointed to the directory), we use KEYPAIR_FILE to point to the actual
private key file of the keypair being used to deploy.  This allows the
keypair and the associated local private key file to be named
independently.
