### PR TITLE
Add chroot SFTP upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ git clone https://github.com/VTUL/geoblacklight-vagrant
 Configuration
 -------------
 
+In all environments, a chroot SFTP upload area is created on the installed server. The upload user is allowed to connect only using public key authentication when using SFTP. This means an `authorized_keys` file should be supplied locally to list the SSH public keys that are permitted to log in as the upload user. This file should be placed in the `files` directory prior to `vagrant up` and should be called `authorized_keys`. (It is in standard .ssh/authorized_keys format.) It can trivially be created by copying your SSH public key file to `files/authorized_keys`.
+
 ### AWS
 
 When using the `aws` provider to `vagrant up` it is necessary to define several environment variables in order to authenticate to AWS and supply a keypair with which Vagrant can log in to the new AWS EC2 instance being deployed.  These environment variables are as follows:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,6 @@ Vagrant.configure(2) do |config|
   config.vm.provider :aws do |aws, override|
     keypair = "#{ENV['KEYPAIR_NAME']}"
     keypair_filename = "#{ENV['KEYPAIR_FILE']}"
-    override.vm.synced_folder '.', '/vagrant', :disabled => true
     override.vm.box = "aws_dummy"
     override.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
     override.vm.box_check_update = false
@@ -50,7 +49,6 @@ Vagrant.configure(2) do |config|
   config.vm.provider :openstack do |os, override|
     keypair = "#{ENV['KEYPAIR_NAME']}"
     keypair_filename = "#{ENV['KEYPAIR_FILE']}"
-    override.vm.synced_folder '.', '/vagrant', :disabled => true
     override.vm.box = "openstack_dummy"
     override.vm.box_url = "https://github.com/cloudbau/vagrant-openstack-plugin/raw/master/dummy.box"
     override.vm.box_check_update = false

--- a/files/.gitignore
+++ b/files/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This update adds an "upload" user that can upload files via SFTP into a
chroot area.  The upload user is restricted only to public key
authentication when using SFTP.  Because of this, an "authorized_keys"
file must be specified in the files/ directory before executing
"vagrant up".  The authorized_keys file determines who may SFTP into
the system using the upload user.

The authorized_keys file is copied into the deployed system via the
/vagrant shared folder mechanism.  This is why shared folders are no
longer disabled for AWS and OpenStack (which use rsync-based one-way
shared folders).
